### PR TITLE
ci(netlify): add Netlify config for PR Deploy Previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Personal website, powered by React + Vite + TypeScript and deployed to https://k
 - `npm run preview` — preview built site
 
 Deploys automatically on push to `master`.
+
+## Vercel Preview Deployments (optional)
+
+This repo includes a `vercel.json` so it can be connected to Vercel for per‑PR preview URLs.
+
+How to enable previews:
+- Install the Vercel GitHub app and import this repository.
+- Framework will be detected (Vite). Build command `npm run build`, output `dist/`.
+- Vercel will post a preview URL on each pull request automatically.
+
+Routing: `vercel.json` rewrites all routes to `/index.html` to support SPA deep links.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ How to enable previews:
 - Netlify will post a preview URL on each PR automatically.
 
 Routing: `netlify.toml` adds a catch‑all redirect to `/index.html` for SPA deep links.
+
+Note:
+- Production remains on GitHub Pages via the Actions workflow; Netlify is used only for PR previews. You can disable “Production deploys” on the Netlify site to avoid confusion.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ Personal website, powered by React + Vite + TypeScript and deployed to https://k
 
 Deploys automatically on push to `master`.
 
-## Vercel Preview Deployments (optional)
+## Netlify Deploy Previews (optional)
 
-This repo includes a `vercel.json` so it can be connected to Vercel for per‑PR preview URLs.
+This repo includes a `netlify.toml` so it can be connected to Netlify for per‑PR Deploy Previews.
 
 How to enable previews:
-- Install the Vercel GitHub app and import this repository.
-- Framework will be detected (Vite). Build command `npm run build`, output `dist/`.
-- Vercel will post a preview URL on each pull request automatically.
+- Sign up/in at https://app.netlify.com and click “Add new site” → “Import an existing project”.
+- Connect GitHub and select `konekoya/konekoya.github.com`.
+- Netlify should auto-detect Vite; if not:
+  - Build command: `npm run build`
+  - Publish directory: `dist`
+- Deploy contexts → ensure “Deploy Previews” are enabled for pull requests.
+- Netlify will post a preview URL on each PR automatically.
 
-Routing: `vercel.json` rewrites all routes to `/index.html` to support SPA deep links.
+Routing: `netlify.toml` adds a catch‑all redirect to `/index.html` for SPA deep links.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm ci && npm run build"
   publish = "dist"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "framework": "vite",
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "cleanUrls": true,
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
-}


### PR DESCRIPTION
Switch from Vercel to Netlify for per‑PR preview URLs.\n\nChanges:\n- Add netlify.toml (build: npm run build, publish: dist, SPA redirects)\n- Update README with Netlify setup steps\n- Remove vercel.json\n\nProduction remains on GitHub Pages via Actions; Netlify is for previews only.