### PR TITLE
docs(agents): sync guidelines with README (CI + structure)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@ Scope: Entire repository. These guidelines apply to all changes unless a more sp
 ## Tech + Tooling
 
 - Primary app lives at repo root (Vite + React + TypeScript, Node 22 via `.nvmrc`).
-- Deploy via GitHub Actions at `.github/workflows/deploy-pages.yml`.
+- CI via GitHub Actions at `.github/workflows/ci.yml`.
+- CI runs format check, lint, typecheck, and build on PRs; pushes to `master` build and deploy to GitHub Pages.
 - Do not re-introduce the legacy Gulp stack.
 
-## Coding Conventions (web/)
+## Coding Conventions
 
 - Language: TypeScript. Prefer explicit types at public boundaries; allow inference internally.
 - React: Functional components with hooks. Avoid class components.
@@ -17,17 +18,22 @@ Scope: Entire repository. These guidelines apply to all changes unless a more sp
 - State: Local state with hooks; lift state only when needed. No external state library unless justified by scale.
 - Fetching: Use `fetch` with proper error handling and fallbacks. Avoid jQuery.
 - Accessibility: Provide `aria-*` labels, semantic tags, and keyboard focus states.
-- Assets: Put static assets in `web/public/` if they must be served as-is; otherwise import via modules.
+- Assets: Put static assets in `public/` if they must be served as-is; otherwise import via modules.
 
 ## Project Structure
 
+- `src/` — Components, styles (CSS Modules), entry.
 - `src/components/` — Reusable UI components.
 - `src/pages/` — Page-level composition (if needed later).
 - `src/styles/` — Global tokens or variables (CSS variables), minimal usage.
+- `public/` — Static assets served as-is.
 
 ## Quality
 
 - Lint/Build: Ensure `npm run build` passes before proposing large changes.
+- ESLint: `npm run lint` must pass with no warnings.
+- TypeScript: `npm run typecheck` must pass.
+- Formatting: `npm run format:check` must pass (CI enforces this).
 - Tests: If adding tests, colocate them (`*.test.tsx`). Keep them fast and focused.
 - Commits: Use concise, conventional messages (feat, fix, chore, docs, ci, refactor, perf, test).
 


### PR DESCRIPTION
Summary: Align AGENTS.md with current README to avoid drift and clarify contributor expectations.

Changes:
- Point CI to `.github/workflows/ci.yml` and document PR checks and deploy on `master`.
- Rename “Coding Conventions (web/)” to “Coding Conventions”.
- Correct static assets path to `public/`.
- Update project structure to `src/` (components/styles/entry) and `public/`.
- Add explicit quality gates: `lint` (no warnings), `typecheck`, and `format:check`.

Rationale: README is the source of truth; AGENTS.md now reflects the actual setup and CI behavior.

Impact: Documentation-only; no runtime or build changes.

Migration: None required.

Verification: Ran `npm run lint` (0 warnings) and `npm run build` (success) locally.
