### PR TITLE
fix(intro): correct employer link to auo.com

### DIFF
--- a/src/components/IntroSection.tsx
+++ b/src/components/IntroSection.tsx
@@ -31,7 +31,7 @@ export function IntroSection() {
           Designer living in Hsinchu, Taiwan 🇹🇼 I'm currently working at{' '}
           <a
             className={`${styles.link} ${styles.linkLeft}`}
-            href="https://en.wikipedia.org/wiki/Hsinchu"
+            href="https://www.auo.com/"
             target="_blank"
             rel="noreferrer"
             data-linktext="AUO"


### PR DESCRIPTION
Fix incorrect employer link in IntroSection.\n\n- Update AUO link href to https://www.auo.com/\n- Docs-only; verified lint and build pass locally.